### PR TITLE
update default setting for background color

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
                 },
                 "carbon.backgroundColor": {
                     "type": "string",
-                    "default": "rgba(171,184,195,100)",
+                    "default": "rgba(171,184,195,1)",
                     "description": "RGBA color to use as the background behind the window.",
                     "pattern": "^rgba\\((([01]?\\d\\d?|2[0-4]\\d|25[0-5]),\\s*){3}([01]|(0?\\.\\d+))\\)$"
                 },


### PR DESCRIPTION
Background color was not loading properly & regex error on background-color setting, if settings were changed, it would use a transparent background in Carbon. When the final value of RGBA was replaced with 1 character instead of 3, regex error went away, and custom color was loading just fine.